### PR TITLE
Add ephemeral  dynamic runner workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
     steps:
+      - name: Check if repo is fork
+        id: is-fork
+        run: echo "::set-output name=fork::$(gh api repos/${{ github.repository }} | jq .fork)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup OS matrix
         id: setup-os-matrix
         run: |
@@ -60,7 +65,7 @@ jobs:
             )
           ) && os+=("macos-latest")
 
-          [ "${{ github.event.repository.fork }}" == "false" ] && os+=("cuda")
+          [ "${{ steps.is-fork.outputs.fork }}" == "false" ] && os+=("cuda")
 
           echo "::set-output name=os::$(jq -cn '$ARGS.positional' --args ${os[@]})"
     outputs:

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -42,15 +42,17 @@ jobs:
           node-version: '14'
 
       - name: Setup Pulumi
+        working-directory: pulumi
         run: |
-          cd pulumi
           curl -fsSL https://get.pulumi.com | sh
           npm install
 
       - name: Pulumi login
+        working-directory: pulumi
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GCE_SA_KEY }}
-        run: pulumi login ${{ secrets.GS_BUCKET }}
+          GS_BUCKET: ${{ secrets.GS_BUCKET }}
+        run: make login
 
       - name: Execute Pulumi
         env:
@@ -61,16 +63,13 @@ jobs:
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
           PULUMI_STACK_NAME: ilgpu_${{ github.event.workflow_run.id }}
           GCE_SA_EMAIL: ${{ secrets.GCE_SA_EMAIL }}
+          REPO: ${{ github.repository }}
+        working-directory: pulumi
         run: |
-          cd pulumi
           if [[ ${{ github.event.action }} == 'requested' ]]; then
-            pulumi stack init -s $PULUMI_STACK_NAME
-            pulumi config set ephemeral-github-runner:repo ${{ github.repository }} --config-file ../ilgpu/config.yaml
-            pulumi up --diff --config-file ../ilgpu/config.yaml -y
+            make up stack=$PULUMI_STACK_NAME config=../ilgpu/config.yaml auto-approve=-y
           elif [[ ${{ github.event.action }} == 'completed' ]]; then
-            pulumi stack select $PULUMI_STACK_NAME
-            pulumi destroy --config-file ../ilgpu/config.yaml -y
-            pulumi stack rm $PULUMI_STACK_NAME -y
+            make down stack=$PULUMI_STACK_NAME config=../ilgpu/config.yaml auto-approve=-y
           else
             echo "Workflow failed. Unrecognized workflow event received: github.event.action=${{ github.event.action }}"
             exit 1

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -7,16 +7,6 @@ on:
       - completed
       - requested
 
-env:
-  PAT: ${{ secrets.PAT }}
-  GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
-  PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
-  GOOGLE_CREDENTIALS: ${{ secrets.GCE_SA_KEY }}
-  GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
-  PULUMI_STACK_NAME: ilgpu_${{ github.event.workflow_run.id }}
-  GS_BUCKET: ${{ secrets.GS_BUCKET }}
-  GCE_SA_EMAIL: ${{ secrets.GCE_SA_EMAIL }}
-
 jobs:
   is-fork:
     runs-on: ubuntu-latest
@@ -28,11 +18,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       fork: ${{ steps.is-fork.outputs.fork }}
-  deploy-runners:
+  manage-runners:
     runs-on: ubuntu-latest
     needs: is-fork
-    if: ${{ github.event.action == 'requested' && needs.is-fork.outputs.fork == 'false' }}
     environment: cuda-test-infra
+    if: ${{ needs.is-fork.outputs.fork == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -51,39 +41,37 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Execute Pulumi
+      - name: Setup Pulumi
         run: |
           cd pulumi
           curl -fsSL https://get.pulumi.com | sh
           npm install
-          pulumi login $GS_BUCKET
-          pulumi stack init -s $PULUMI_STACK_NAME
-          pulumi up --diff --config-file ../ilgpu/config.yaml -y
 
-  destroy-runners:
-    runs-on: ubuntu-latest
-    needs: is-fork
-    if: ${{ github.event.action == 'completed' && needs.is-fork.outputs.fork == 'false' }}
-    environment: cuda-test-infra
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          path: ilgpu
-
-      - name: Checkout Pulumi Ephemeral Github Runner project
-        uses: actions/checkout@v2
-        with:
-          repository: pavlovic-ivan/ephemeral-github-runner-gcp
-          ref: main
-          path: pulumi
+      - name: Pulumi login
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCE_SA_KEY }}
+        run: pulumi login ${{ secrets.GS_BUCKET }}
 
       - name: Execute Pulumi
+        env:
+          PAT: ${{ secrets.PAT }}
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GCE_SA_KEY }}
+          GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
+          PULUMI_STACK_NAME: ilgpu_${{ github.event.workflow_run.id }}
+          GCE_SA_EMAIL: ${{ secrets.GCE_SA_EMAIL }}
         run: |
           cd pulumi
-          curl -fsSL https://get.pulumi.com | sh
-          npm install
-          pulumi login $GS_BUCKET
-          pulumi stack select $PULUMI_STACK_NAME
-          pulumi destroy --config-file artifacts/config.yaml -y
-          pulumi stack rm $PULUMI_STACK_NAME -y
+          if [[ ${{ github.event.action }} == 'requested' ]]; then
+            pulumi stack init -s $PULUMI_STACK_NAME
+            pulumi config set ephemeral-github-runner:repo ${{ github.repository }} --config-file ../ilgpu/config.yaml
+            pulumi up --diff --config-file ../ilgpu/config.yaml -y
+          elif [[ ${{ github.event.action }} == 'completed' ]]; then
+            pulumi stack select $PULUMI_STACK_NAME
+            pulumi destroy --config-file ../ilgpu/config.yaml -y
+            pulumi stack rm $PULUMI_STACK_NAME -y
+          else
+            echo "Workflow failed. Unrecognized workflow event received: github.event.action=${{ github.event.action }}"
+            exit 1
+          fi

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -55,7 +55,6 @@ jobs:
           REPO: ${{ github.repository }}
         working-directory: pulumi
         run: |
-          action=''
           case ${{ github.event.action }} in
             'requested')
               action=up

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -8,21 +8,10 @@ on:
       - requested
 
 jobs:
-  is-fork:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if repo is fork
-        id: is-fork
-        run: echo "::set-output name=fork::$(gh api repos/${{ github.repository }} | jq .fork)"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    outputs:
-      fork: ${{ steps.is-fork.outputs.fork }}
   manage-runners:
     runs-on: ubuntu-latest
-    needs: is-fork
     environment: cuda-test-infra
-    if: ${{ needs.is-fork.outputs.fork == 'false' }}
+    if: ${{ !github.event.repository.fork }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -66,11 +55,13 @@ jobs:
           REPO: ${{ github.repository }}
         working-directory: pulumi
         run: |
-          if [[ ${{ github.event.action }} == 'requested' ]]; then
-            make up stack=$PULUMI_STACK_NAME config=../ilgpu/config.yaml auto-approve=-y
-          elif [[ ${{ github.event.action }} == 'completed' ]]; then
-            make down stack=$PULUMI_STACK_NAME config=../ilgpu/config.yaml auto-approve=-y
-          else
-            echo "Workflow failed. Unrecognized workflow event received: github.event.action=${{ github.event.action }}"
-            exit 1
-          fi
+          action=''
+          case ${{ github.event.action }} in
+            'requested')
+              action=up
+              ;;
+            'completed')
+              action=down
+              ;;
+          esac
+          make $action stack=$PULUMI_STACK_NAME config=../ilgpu/config.yaml auto-approve=-y

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -1,0 +1,89 @@
+name: Runners Deployment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: 
+      - completed
+      - requested
+
+env:
+  PAT: ${{ secrets.PAT }}
+  GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+  PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+  GOOGLE_CREDENTIALS: ${{ secrets.GCE_SA_KEY }}
+  GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
+  PULUMI_STACK_NAME: ilgpu_${{ github.event.workflow_run.id }}
+  GS_BUCKET: ${{ secrets.GS_BUCKET }}
+  GCE_SA_EMAIL: ${{ secrets.GCE_SA_EMAIL }}
+
+jobs:
+  is-fork:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if repo is fork
+        id: is-fork
+        run: echo "::set-output name=fork::$(gh api repos/${{ github.repository }} | jq .fork)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      fork: ${{ steps.is-fork.outputs.fork }}
+  deploy-runners:
+    runs-on: ubuntu-latest
+    needs: is-fork
+    if: ${{ github.event.action == 'requested' && needs.is-fork.outputs.fork == 'false' }}
+    environment: cuda-test-infra
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ilgpu
+
+      - name: Checkout Pulumi Ephemeral Github Runner project
+        uses: actions/checkout@v2
+        with:
+          repository: pavlovic-ivan/ephemeral-github-runner-gcp
+          ref: main
+          path: pulumi
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Execute Pulumi
+        run: |
+          cd pulumi
+          curl -fsSL https://get.pulumi.com | sh
+          npm install
+          pulumi login $GS_BUCKET
+          pulumi stack init -s $PULUMI_STACK_NAME
+          pulumi up --diff --config-file ../ilgpu/config.yaml -y
+
+  destroy-runners:
+    runs-on: ubuntu-latest
+    needs: is-fork
+    if: ${{ github.event.action == 'completed' && needs.is-fork.outputs.fork == 'false' }}
+    environment: cuda-test-infra
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ilgpu
+
+      - name: Checkout Pulumi Ephemeral Github Runner project
+        uses: actions/checkout@v2
+        with:
+          repository: pavlovic-ivan/ephemeral-github-runner-gcp
+          ref: main
+          path: pulumi
+
+      - name: Execute Pulumi
+        run: |
+          cd pulumi
+          curl -fsSL https://get.pulumi.com | sh
+          npm install
+          pulumi login $GS_BUCKET
+          pulumi stack select $PULUMI_STACK_NAME
+          pulumi destroy --config-file artifacts/config.yaml -y
+          pulumi stack rm $PULUMI_STACK_NAME -y

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -50,6 +50,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           GOOGLE_CREDENTIALS: ${{ secrets.GCE_SA_KEY }}
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
+          GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
           PULUMI_STACK_NAME: ilgpu_${{ github.event.workflow_run.id }}
           GCE_SA_EMAIL: ${{ secrets.GCE_SA_EMAIL }}
           REPO: ${{ github.repository }}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,12 @@
+config:
+  ephemeral-github-runner:bootDiskSizeInGB: 200
+  ephemeral-github-runner:bootDiskType: pd-balanced
+  ephemeral-github-runner:env: dev
+  ephemeral-github-runner:ghRunnerName: orville
+  ephemeral-github-runner:machineImage: projects/gr-oss-251320/global/images/ubuntu-2004-focal-v20211202-ghrv22851
+  ephemeral-github-runner:machineType: a2-highgpu-1g
+  ephemeral-github-runner:repo: ILGPU
+  ephemeral-github-runner:repoOwner: m4rs-mt
+  ephemeral-github-runner:runnersCount: 6
+  ephemeral-github-runner:serviceAccountScopes: https://www.googleapis.com/auth/cloud-platform
+  ephemeral-github-runner:zone: europe-west4-a

--- a/config.yaml
+++ b/config.yaml
@@ -6,4 +6,3 @@ config:
   ephemeral-github-runner:machineType: a2-highgpu-1g
   ephemeral-github-runner:runnersCount: 6
   ephemeral-github-runner:serviceAccountScopes: https://www.googleapis.com/auth/cloud-platform
-  ephemeral-github-runner:zone: europe-west4-a

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,7 @@
 config:
   ephemeral-github-runner:bootDiskSizeInGB: 200
   ephemeral-github-runner:bootDiskType: pd-balanced
-  ephemeral-github-runner:env: dev
-  ephemeral-github-runner:ghRunnerName: orville
+  ephemeral-github-runner:ghRunnerName: ilgpu-ghrunner
   ephemeral-github-runner:machineImage: projects/gr-oss-251320/global/images/ubuntu-2004-focal-v20211202-ghrv22851
   ephemeral-github-runner:machineType: a2-highgpu-1g
   ephemeral-github-runner:runnersCount: 6

--- a/config.yaml
+++ b/config.yaml
@@ -5,8 +5,6 @@ config:
   ephemeral-github-runner:ghRunnerName: orville
   ephemeral-github-runner:machineImage: projects/gr-oss-251320/global/images/ubuntu-2004-focal-v20211202-ghrv22851
   ephemeral-github-runner:machineType: a2-highgpu-1g
-  ephemeral-github-runner:repo: ILGPU
-  ephemeral-github-runner:repoOwner: m4rs-mt
   ephemeral-github-runner:runnersCount: 6
   ephemeral-github-runner:serviceAccountScopes: https://www.googleapis.com/auth/cloud-platform
   ephemeral-github-runner:zone: europe-west4-a


### PR DESCRIPTION
**Intention**

The intention of this PR is to provide the project the ability to deploy dynamic runners that will run CUDA jobs, by adding new runners workflow. In order to have the complete feature, Github repo needs to be configured. More about that bellow in the Guide.

**Guide**

This guide explains how to configure Github repo. First, the prerequisits. You need a protected environment. If none exist:

1. Go to `Settings` > `Environments` > `New environment`
2. Give the Environment a name `cuda-test-infra`
3. Select a branch for which this Environment will be available by selecting the option "Selected branches" in the drop down menu of `Deployment branches`.
4. Select "+ Add deployment branch rule"
5. In the popup window enter the name of the main branch (eg, main, master, whichever is the main for your repo)

Now, make sure you have a Personal Access Token (PAT) set. If not:

1. Open Your Profile > `Settings` > `Developer Settings` > `Personal access tokens`
2. Select `Generate new token`
3. Give the token a name
4. Set expiration to "No expiration"
5. Select scopes for the token: `repo: Full control of private repositories`
6. Select `Generate token`
7. Copy the token and save it, it is visible to you only once

After the Environment [exists/is created], add new Environment secrets (provided safely offline), but:

- Select "+ Add Secret" within selected Environment (Environment named `cuda-test-infra`)

**Working example**

A working example can be seen [here](https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/1848580697). You will see that CUDA tests are green. Workflow failed on `publish-preview` job, as i don't have perms and secrets needed to make it successful.

When this workflow was created, it created an event that triggered a workflow that deploys the runners. Workflow available [here](https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/1848580754). Once the main CI workflow is done, another event triggers a workflow that destroys the created runners (as seen [here](https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/1848719253)).

**Further steps before accepting PR**

- [ ] Communicate securely with upstream maintainer. Provide secrets needed to deploy runners to GR GCP project